### PR TITLE
F8: Prepare yaml config for user collection creating

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,9 +7,11 @@ apps:
       connection_url: "postgresql://admin:admin@localhost:5432/gouth?search_path=public"
     auth:
       use_custom_collection: true
-      auth_collection: "users"
-      user_identifier: "username"
-      user_confirmation: "password"
+      user_collection:
+        name: "users"
+        pk: "id"
+        user_id: "username"
+        user_confirm: "password"
       login:
         fields:
           "$.name": "username"
@@ -28,15 +30,16 @@ apps:
       connection_url: "mongodb://admin:admin@localhost:27017/gouth"
     auth:
       use_custom_collection: true
-      auth_collection: "users"
-      user_identifier: "username"
-      user_confirmation: "password"
+      user_collection:
+        name: "users"
+        user_id: "username"
+        user_confirm: "password"
       login:
         fields:
           "$.name": "username"
           "$.passwd": "password"
         payload:
-          "$.userID": "id"
+          "$.userID": "_id"
       register:
         login_after: true
         fields:


### PR DESCRIPTION
In the MongoDB we can't change the default primary key field (_id), so "collection_pk" may be omitted for a MongoDB